### PR TITLE
Distance fix

### DIFF
--- a/src/imaginghelper.js
+++ b/src/imaginghelper.js
@@ -566,15 +566,18 @@
          *
          **/
         vectorToDistance: function (vector,from,to) {
-			if (!this._haveImage) return 0;
+			if (!this._haveImage) {
+				return 0;
+			}
 			
-			var toVector;
+			var toVector,logical,physical,data;
 			toVector=vector;
 			
 			logical=['l','log','logical'];
 			physical=['p','phys','physical'];
 			data=['d','data'];
 			
+			if (typeof from !== 'undefined' && typeof to !== 'undefined') {
 			from=from.toLowerCase();
 			to=to.toLowerCase();
 			
@@ -596,6 +599,7 @@
 				} else if (logical.indexOf(to)>-1) {
 					toVector=this.physicalToLogicalPoint(vector);
 				}
+			}
 			}
 			
             return Math.sqrt((toVector.x * toVector.x) + (toVector.y * toVector.y));

--- a/src/imaginghelper.js
+++ b/src/imaginghelper.js
@@ -565,6 +565,48 @@
          * @method
          *
          **/
+        vectorToDistance: function (vector,from,to) {
+			if (!this._haveImage) return 0;
+			
+			var toVector;
+			toVector=vector;
+			
+			logical=['l','log','logical'];
+			physical=['p','phys','physical'];
+			data=['d','data'];
+			
+			from=from.toLowerCase();
+			to=to.toLowerCase();
+			
+			if (logical.indexOf(from)>-1) {
+				if (physical.indexOf(to)>-1) {
+					toVector=this.logicalToPhysicalPoint(vector);
+				} else if (data.indexOf(to)>-1) {
+					toVector=this.logicalToDataPoint(vector);
+				}
+			} else if (data.indexOf(from)>-1) {
+				if (physical.indexOf(to)>-1) {
+					toVector=this.dataToPhysicalPoint(vector);
+				} else if (logical.indexOf(to)>-1) {
+					toVector=this.dataToLogicalPoint(vector);
+				}
+			} else if (physical.indexOf(from)>-1) {
+				if (data.indexOf(to)>-1) {
+					toVector=this.physicalToDatalPoint(vector);
+				} else if (logical.indexOf(to)>-1) {
+					toVector=this.physicalToLogicalPoint(vector);
+				}
+			}
+			
+            return Math.sqrt((toVector.x * toVector.x) + (toVector.y * toVector.y));
+        },
+
+        /**
+         *
+         *
+         * @method
+         *
+         **/
         logicalToDataPoint: function (point) {
             return new OpenSeadragon.Point(this.logicalToDataX(point.x), this.logicalToDataY(point.y));
         },

--- a/src/imaginghelper.js
+++ b/src/imaginghelper.js
@@ -563,6 +563,9 @@
          *
          *
          * @method
+		 * @param {external:"OpenSeadragon.Point"} [vector] - Point offset from zero
+		 * @param {string} [from] - Originating coordinate space ('l','p','d')
+		 * @param {string} [to] - Destination coordinate space ('l','p','d')
          *
          **/
         vectorToDistance: function (vector,from,to) {


### PR DESCRIPTION
As mentioned in issue-comment.
Instead of calling a one-dimensional conversion, a vector is passed to  generate the (absolute) magnitude of it's length. This can be done independently of coordinate system, and will return value local to the same system.

Also by supplying optional **originating coordinate space** and **destination coordinate space** a conversion will be made - e.g. `'vectorToDistance(aPoint,'p','l')` returns a magnitude value in logical space of the vector `aPoint` given in physical space. Aliases for `'p', 'l', 'd'` are also available.

For getting a one-dimensional conversion, the dimension not to be included is simply put to zero.

Old methods were not removed.